### PR TITLE
Download 'uefi-ntfs.img' from jsDelivr CDN

### DIFF
--- a/sbin/woeusb
+++ b/sbin/woeusb
@@ -1072,7 +1072,7 @@ install_uefi_ntfs_support_partition(){
 
     if ! wget \
         --directory-prefix="${download_directory}" \
-        https://github.com/pbatard/rufus/raw/master/res/uefi/uefi-ntfs.img; then
+        https://cdn.jsdelivr.net/gh/pbatard/rufus@3.13/res/uefi/uefi-ntfs.img; then
         printf_with_color yellow \
             '%s: %s\n' \
             "${FUNCNAME[0]}" \


### PR DESCRIPTION
Because of DNS pollution, raw.githubusercontent.com is not properly accessible in mainland China