### PR TITLE
Fix for "integer expression expected"

### DIFF
--- a/sbin/woeusb
+++ b/sbin/woeusb
@@ -1356,7 +1356,7 @@ copy_filesystem_files(){
                     'Copying "%s"...\n' \
                     "${source_file}"
             fi
-            if [ "${source_file_size}" -lt "${dd_block_size}" ]; then
+            if [[ "${source_file_size}" -lt "${dd_block_size}" ]]; then
                 cp "${source_file}" "${dest_file}"
             else
                 # FS_FAT is not a parameter expansion


### PR DESCRIPTION
I was using this earlier today and ran into a bug where my terminal was filled with the following line:
`./sbin/woeusb: line 1359: [: ((4 * 1024 * 1024)): integer expression expected`
The following change fixes the error.

GNU bash version 4.4.19(1)-release