### PR TITLE
Fix grub-install Input/output error

### DIFF
--- a/sbin/woeusb
+++ b/sbin/woeusb
@@ -1886,6 +1886,7 @@ install_legacy_pc_bootloader_grub(){
 
     print_info \
         "$(gettext 'Installing GRUB bootloader for legacy PC booting support...\n')"
+    mkdir -p "${target_fs_mountpoint}/grub/locale"
     "${command_grubinstall}" \
         --target=i386-pc \
         --boot-directory="${target_fs_mountpoint}" \


### PR DESCRIPTION
During grub-install error like this rising:
grub-install: error: cannot copy `/usr/share/locale-langpack/en@quot/LC_MESSAGES/grub.mo' to `/tmp/woeusb-target-20230730-170805-Sunday.16gHPc/grub/locale/en@quot.mo': Input/output error.

Because `grub/locale/` dir not created before running the command.